### PR TITLE
Allow YAML documents to use aliasing

### DIFF
--- a/lib/config_hound/parser.rb
+++ b/lib/config_hound/parser.rb
@@ -16,7 +16,7 @@ module ConfigHound
 
     def parse_yaml(raw)
       require "yaml"
-      YAML.safe_load(raw)
+      YAML.safe_load(raw, [], [], true)
     end
 
     alias :parse_yml :parse_yaml

--- a/spec/features/formats_spec.rb
+++ b/spec/features/formats_spec.rb
@@ -20,6 +20,20 @@ describe ConfigHound, "formats" do
     )
   end
 
+  given_resource "config-with-aliases.yml", %{
+    foo: &foo
+      bar: 1
+    baz:
+      <<: *foo
+  }
+
+  it "loads YAML with aliases" do
+    expect(load("config-with-aliases.yml")).to eq(
+      "foo" => { "bar" => 1 },
+      "baz" => { "bar" => 1 }
+    )
+  end
+
   given_resource "config.json", %{
     {
       "foo": 1,


### PR DESCRIPTION
Use the example in YAML#safe_load[1] to restore alias support. Fixes #2 .

[1] https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load